### PR TITLE
switching to StaticJsonRpcProvider

### DIFF
--- a/nft-snapshot.js
+++ b/nft-snapshot.js
@@ -8,7 +8,7 @@ const PROVIDER_ENDPOINT; // INSERT
 const CHAIN_ID = 1;
 const FORMAT = "tokensByOwner"; // options: "tokensByOwner" or "ownerByTokenId"
 
-const provider = new ethers.providers.JsonRpcProvider(PROVIDER_ENDPOINT, CHAIN_ID);
+const provider = new ethers.providers.StaticJsonRpcProvider(PROVIDER_ENDPOINT, CHAIN_ID);
 const abi = ["function ownerOf (uint256) view returns (address)"];
 const contract = new ethers.Contract(TOKEN_ADDRESS, abi, provider);
 


### PR DESCRIPTION
This saves API Requests to Infura and also speeds up execution.
From the ethers docs:

// A StaticJsonRpcProvider is useful when you *know* for certain that
// the backend will never change, as it never calls eth_chainId to
// verify its backend. However, if the backend does change, the effects
// are undefined and may include:
// - inconsistent results
// - locking up the UI
// - block skew warnings
// - wrong results
// If the network is not explicit (i.e. auto-detection is expected), the
// node MUST be running and available to respond to requests BEFORE this
// is instantiated.